### PR TITLE
chore: add CI workflow and drop npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci --omit=dev
+      - run: npm test
+      - name: Deploy
+        run: echo "Deploy step placeholder"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-omit=dev


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies without dev packages and marks production environment
- remove obsolete .npmrc config

## Testing
- `npm test` *(fails: Smoke check failed: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb2dbba7c8329ab13e3899421882f