### PR TITLE
Loosen MACD alert restrictions for more signals

### DIFF
--- a/scripts/system-test.js
+++ b/scripts/system-test.js
@@ -52,8 +52,7 @@ async function testAlertController(candles) {
       slow: 26,
       signal: 9,
       lookbackBars: 1,
-      requireClosedBar: false,
-      useZeroLine: false
+      requireClosedBar: false
     };
 
     console.log(`Testing alert detection for ${symbol}...`);


### PR DESCRIPTION
## Summary
- Remove slope and zero-line confirmations from MACD alert logic
- Allow open last candle and search up to five bars back by default
- Update system test options to match simplified alert logic

## Testing
- `node scripts/system-test.js` *(fails: fetch failed for Yahoo Finance service)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1d6bf948329a0f2535290aa0fd6